### PR TITLE
Fixed issue #1

### DIFF
--- a/src/test/java/io/klerch/alexa/tellask/model/wrapper/AlexaSpeechletResponseTest.java
+++ b/src/test/java/io/klerch/alexa/tellask/model/wrapper/AlexaSpeechletResponseTest.java
@@ -64,6 +64,24 @@ public class AlexaSpeechletResponseTest {
                 ((SsmlOutputSpeech)response.getOutputSpeech()).getSsml());
         Assert.assertNull(response.getReprompt());
     }
+    // RJH FEB 2017 - added test for issue:
+    // ~ https://github.com/KayLerch/alexa-skills-kit-tellask-java/issues/1
+    @Test
+    public void getResponseWithSlotsMatcherQuoteReplacement() throws Exception {
+        final AlexaStateModelSample model = new AlexaStateModelSample();
+        model.setName("Paul");
+
+        final AlexaOutput output = AlexaOutput
+                .ask("IntentWithOneSlotReplacement")
+                .putSlot("theSlot", "$5.00")
+                .putState(model).build();
+
+        final AlexaSpeechletResponse response = new AlexaSpeechletResponse(output, new ResourceUtteranceReader(), "en-US");
+        Assert.assertEquals(output, response.getOutput());
+        Assert.assertEquals("<speak>This is a single slot replacement: $5.00</speak>",
+                ((SsmlOutputSpeech)response.getOutputSpeech()).getSsml());
+        Assert.assertNull(response.getReprompt());
+    }
 
     @Test
     public void getResponseWithReprompt() throws Exception {

--- a/src/test/resources/en-US/utterances.yml
+++ b/src/test/resources/en-US/utterances.yml
@@ -43,6 +43,10 @@ IntentWithOneUtteranceAndOneReprompt:
   Reprompts:
     - "This is a reprompt {name} with your score of {credits}"
 
+IntentWithOneSlotReplacement:
+  Utterances:
+    - "This is a single slot replacement: {theSlot}"
+
 IntentWithInstantUtterance:
   - "Hello there {name}. Your current score is {credits} This is awesome"
   - "Welcome {name}. You got a score of {credits} You are awesome"


### PR DESCRIPTION
Hi Kay, I fixed the issue by adding the Matcher.quoteReplacement to the resolveSlotsInUtterance method, did some minor refactoring of that method and added a test. I compiled and all tests passed. Please review. Thanks.

Added "Matcher.quoteReplacement" to resolve of slot input in AlexaSpeechletResponse::resolveSlotsInUtterance.
Added test to confirm that slots with replacement text containing $ does not fail with exception
Added entry to utterance.yaml for test
Minor refactor of resolveSlotsInUtterance, broke out double lambda into a lambda & method to improve code readability (see inline comment)